### PR TITLE
tidy(src/app)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM 1and1internet/ubuntu-16-nginx-passenger
 MAINTAINER brian.wilkinson@1and1.co.uk
 ARG DEBIAN_FRONTEND=noninteractive
-COPY src /usr/src
 COPY files /
 RUN \
 	apt-get update -q && \

--- a/files/usr/src/app.js
+++ b/files/usr/src/app.js
@@ -1,0 +1,9 @@
+var http = require('http');
+
+var server = http.createServer(function (request, response) {
+  response.writeHead(200, {"Content-Type": "text/plain"});
+  response.end("Welcome to your nodejs 6 environment\n");
+});
+
+server.listen(3000);
+console.log("Server running at http://127.0.0.1:3000/");


### PR DESCRIPTION
move src/app into files/usr
this will cause it to get copyed to the right place without needing a specific directive